### PR TITLE
tests: unit tests for NMDeviceState and NMDeviceTypeTest

### DIFF
--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.nm.configuration;
+
+public class NMDeviceStateTest {
+
+}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
@@ -25,85 +25,85 @@ public class NMDeviceStateTest {
 	@Test
 	public void conversionWorksForStateUnknown() {
 		whenInt32StateIsPassed(new UInt32(0));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
 	}
 
 	@Test
 	public void conversionWorksForStateUnmanaged() {
 		whenInt32StateIsPassed(new UInt32(10));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
 	}
 
 	@Test
 	public void conversionWorksForStateUnavailable() {
 		whenInt32StateIsPassed(new UInt32(20));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
 	}
 
 	@Test
 	public void conversionWorksForStateDisconnected() {
 		whenInt32StateIsPassed(new UInt32(30));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
 	}
 
 	@Test
 	public void conversionWorksForStatePrepare() {
 		whenInt32StateIsPassed(new UInt32(40));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_PREPARE);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_PREPARE);
 	}
 
 	@Test
 	public void conversionWorksForStateConfig() {
 		whenInt32StateIsPassed(new UInt32(50));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_CONFIG);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_CONFIG);
 	}
 
 	@Test
 	public void conversionWorksForStateNeedAuth() {
 		whenInt32StateIsPassed(new UInt32(60));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
 	}
 
 	@Test
 	public void conversionWorksForStateIpConfig() {
 		whenInt32StateIsPassed(new UInt32(70));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
 	}
 
 	@Test
 	public void conversionWorksForStateIpCheck() {
 		whenInt32StateIsPassed(new UInt32(80));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
 	}
 
 	@Test
 	public void conversionWorksForStateSecondaries() {
 		whenInt32StateIsPassed(new UInt32(90));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
 	}
 
 	@Test
 	public void conversionWorksForStateActivated() {
 		whenInt32StateIsPassed(new UInt32(100));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
 	}
 
 	@Test
 	public void conversionWorksForStateDeactivating() {
 		whenInt32StateIsPassed(new UInt32(110));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
 	}
 
 	@Test
 	public void conversionWorksForStateFailed() {
 		whenInt32StateIsPassed(new UInt32(120));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_FAILED);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_FAILED);
 	}
 
 	@Test
 	public void conversionWorksForStateUnknownDefault() {
 		whenInt32StateIsPassed(new UInt32(121));
-		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+		thenStateShouldBeEqualTo(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
 	}
 
 	@Test
@@ -192,7 +192,7 @@ public class NMDeviceStateTest {
 		state = type;
 	}
 
-	public void thenCorrectStateIsReturned(NMDeviceState type) {
+	public void thenStateShouldBeEqualTo(NMDeviceState type) {
 		assertEquals(state, type);
 	}
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
@@ -109,79 +109,79 @@ public class NMDeviceStateTest {
 	@Test
 	public void shouldReturnConnectionFalseUnknown() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
-		thenStateShouldBeEqualTo(false);
+		thenIsConnectShouldReturn(false);
 	}
 
 	@Test
 	public void shouldReturnConnectionFalseUnmanaged() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
-		thenStateShouldBeEqualTo(false);
+		thenIsConnectShouldReturn(false);
 	}
 
 	@Test
 	public void shouldReturnConnectionFalseUnavailable() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
-		thenStateShouldBeEqualTo(false);
+		thenIsConnectShouldReturn(false);
 	}
 
 	@Test
 	public void shouldReturnConnectionFalseDisconnected() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
-		thenStateShouldBeEqualTo(false);
+		thenIsConnectShouldReturn(false);
 	}
 
 	@Test
 	public void shouldReturnConnectionTruePrepare() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_PREPARE);
-		thenStateShouldBeEqualTo(true);
+		thenIsConnectShouldReturn(true);
 	}
 
 	@Test
 	public void shouldReturnConnectionTrueConfig() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_CONFIG);
-		thenStateShouldBeEqualTo(true);
+		thenIsConnectShouldReturn(true);
 	}
 
 	@Test
 	public void shouldReturnConnectionTrueNeedAuth() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
-		thenStateShouldBeEqualTo(true);
+		thenIsConnectShouldReturn(true);
 	}
 
 	@Test
 	public void shouldReturnConnectionTrueIpConfig() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
-		thenStateShouldBeEqualTo(true);
+		thenIsConnectShouldReturn(true);
 	}
 
 	@Test
 	public void shouldReturnConnectionTrueIpCheck() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
-		thenStateShouldBeEqualTo(true);
+		thenIsConnectShouldReturn(true);
 	}
 
 	@Test
 	public void shouldReturnConnectionTrueSecondaries() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
-		thenStateShouldBeEqualTo(true);
+		thenIsConnectShouldReturn(true);
 	}
 
 	@Test
 	public void shouldReturnConnectionTrueActivated() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
-		thenStateShouldBeEqualTo(true);
+		thenIsConnectShouldReturn(true);
 	}
 
 	@Test
 	public void shouldReturnConnectionTrueDeactivating() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
-		thenStateShouldBeEqualTo(true);
+		thenIsConnectShouldReturn(true);
 	}
 
 	@Test
 	public void shouldReturnConnectionTrueFailed() {
 		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_FAILED);
-		thenStateShouldBeEqualTo(true);
+		thenIsConnectShouldReturn(true);
 	}
 
 	public void whenInt32StateIsPassed(UInt32 type) {
@@ -196,7 +196,7 @@ public class NMDeviceStateTest {
 		assertEquals(state, type);
 	}
 
-	public void thenStateShouldBeEqualTo(Boolean bool) {
+	public void thenIsConnectShouldReturn(Boolean bool) {
 		assertEquals(NMDeviceState.isConnected(state), bool);
 	}
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
@@ -12,6 +12,170 @@
  ******************************************************************************/
 package org.eclipse.kura.nm.configuration;
 
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.kura.KuraException;
+import org.freedesktop.dbus.types.UInt32;
+import org.junit.Test;
+
 public class NMDeviceStateTest {
+	
+	NMDeviceState state;
+	
+    @Test
+    public void shouldReturnCorrectStateTypeZero() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(0));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+    }
+    
+    @Test
+    public void shouldReturnCorrectStateTypeTen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(10));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeTwenty() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(20));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeThirty() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(30));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeForty() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(40));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_PREPARE);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeFifty() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(50));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_CONFIG);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeSixty() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(60));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeSeventy() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(70));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeEighty() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(80));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeNinety() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(90));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeHundred() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(100));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeHundredTen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(110));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
+    }
+    @Test
+    public void shouldReturnCorrectStateTypeHundredTwenty() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(120));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_FAILED);
+    }
+    
+    @Test
+    public void shouldReturnCorrectStateTypeHundredOther() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(121));
+    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+    }
+    
+    @Test
+    public void shouldReturnConnectionFalseUnknown() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+    	thenIsConnectShouldReturn(false);
+    }
+    @Test
+    public void shouldReturnConnectionFalseUnmanaged() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
+    	thenIsConnectShouldReturn(false);
+    }
+    @Test
+    public void shouldReturnConnectionFalseUnavailable() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
+    	thenIsConnectShouldReturn(false);
+    }
+    
+    @Test
+    public void shouldReturnConnectionFalseDisconnected() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+    	thenIsConnectShouldReturn(false);
+    }
+    @Test
+    public void shouldReturnConnectionTruePrepare() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_PREPARE);
+    	thenIsConnectShouldReturn(true);
+    }
+    @Test
+    public void shouldReturnConnectionTrueConfig() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_CONFIG);
+    	thenIsConnectShouldReturn(true);
+    }
+    @Test
+    public void shouldReturnConnectionTrueNeedAuth() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
+    	thenIsConnectShouldReturn(true);
+    }
+    @Test
+    public void shouldReturnConnectionTrueIpConfig() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
+    	thenIsConnectShouldReturn(true);
+    }
+    @Test
+    public void shouldReturnConnectionTrueIpCheck() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
+    	thenIsConnectShouldReturn(true);
+    }
+    @Test
+    public void shouldReturnConnectionTrueSecondaries() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
+    	thenIsConnectShouldReturn(true);
+    }
+    @Test
+    public void shouldReturnConnectionTrueActivated() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+    	thenIsConnectShouldReturn(true);
+    }
+    @Test
+    public void shouldReturnConnectionTrueDeactivating() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
+    	thenIsConnectShouldReturn(true);
+    }
+    @Test
+    public void shouldReturnConnectionTrueFailed() throws InterruptedException, KuraException {
+    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_FAILED);
+    	thenIsConnectShouldReturn(true);
+    }
+
+    public void whenInt32StateIsPassed(UInt32 type){
+    	state = NMDeviceState.fromUInt32(type);
+    }
+    
+    public void whenStateIsSetTo(NMDeviceState type){
+    	state = type;
+    }
+    
+    public void thenCorrectStateIsReturned(NMDeviceState type){
+    	assertEquals(state, type);
+    }
+    
+    public void thenIsConnectShouldReturn(Boolean bool){
+    	assertEquals(NMDeviceState.isConnected(state), bool);
+    }
 
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceStateTest.java
@@ -19,163 +19,185 @@ import org.freedesktop.dbus.types.UInt32;
 import org.junit.Test;
 
 public class NMDeviceStateTest {
-	
-	NMDeviceState state;
-	
-    @Test
-    public void shouldReturnCorrectStateTypeZero() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(0));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
-    }
-    
-    @Test
-    public void shouldReturnCorrectStateTypeTen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(10));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeTwenty() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(20));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeThirty() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(30));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeForty() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(40));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_PREPARE);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeFifty() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(50));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_CONFIG);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeSixty() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(60));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeSeventy() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(70));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeEighty() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(80));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeNinety() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(90));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeHundred() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(100));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeHundredTen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(110));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
-    }
-    @Test
-    public void shouldReturnCorrectStateTypeHundredTwenty() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(120));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_FAILED);
-    }
-    
-    @Test
-    public void shouldReturnCorrectStateTypeHundredOther() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(121));
-    	thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
-    }
-    
-    @Test
-    public void shouldReturnConnectionFalseUnknown() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
-    	thenIsConnectShouldReturn(false);
-    }
-    @Test
-    public void shouldReturnConnectionFalseUnmanaged() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
-    	thenIsConnectShouldReturn(false);
-    }
-    @Test
-    public void shouldReturnConnectionFalseUnavailable() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
-    	thenIsConnectShouldReturn(false);
-    }
-    
-    @Test
-    public void shouldReturnConnectionFalseDisconnected() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
-    	thenIsConnectShouldReturn(false);
-    }
-    @Test
-    public void shouldReturnConnectionTruePrepare() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_PREPARE);
-    	thenIsConnectShouldReturn(true);
-    }
-    @Test
-    public void shouldReturnConnectionTrueConfig() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_CONFIG);
-    	thenIsConnectShouldReturn(true);
-    }
-    @Test
-    public void shouldReturnConnectionTrueNeedAuth() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
-    	thenIsConnectShouldReturn(true);
-    }
-    @Test
-    public void shouldReturnConnectionTrueIpConfig() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
-    	thenIsConnectShouldReturn(true);
-    }
-    @Test
-    public void shouldReturnConnectionTrueIpCheck() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
-    	thenIsConnectShouldReturn(true);
-    }
-    @Test
-    public void shouldReturnConnectionTrueSecondaries() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
-    	thenIsConnectShouldReturn(true);
-    }
-    @Test
-    public void shouldReturnConnectionTrueActivated() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
-    	thenIsConnectShouldReturn(true);
-    }
-    @Test
-    public void shouldReturnConnectionTrueDeactivating() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
-    	thenIsConnectShouldReturn(true);
-    }
-    @Test
-    public void shouldReturnConnectionTrueFailed() throws InterruptedException, KuraException {
-    	whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_FAILED);
-    	thenIsConnectShouldReturn(true);
-    }
 
-    public void whenInt32StateIsPassed(UInt32 type){
-    	state = NMDeviceState.fromUInt32(type);
-    }
-    
-    public void whenStateIsSetTo(NMDeviceState type){
-    	state = type;
-    }
-    
-    public void thenCorrectStateIsReturned(NMDeviceState type){
-    	assertEquals(state, type);
-    }
-    
-    public void thenIsConnectShouldReturn(Boolean bool){
-    	assertEquals(NMDeviceState.isConnected(state), bool);
-    }
+	NMDeviceState state;
+
+	@Test
+	public void conversionWorksForStateUnknown() {
+		whenInt32StateIsPassed(new UInt32(0));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+	}
+
+	@Test
+	public void conversionWorksForStateUnmanaged() {
+		whenInt32StateIsPassed(new UInt32(10));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
+	}
+
+	@Test
+	public void conversionWorksForStateUnavailable() {
+		whenInt32StateIsPassed(new UInt32(20));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
+	}
+
+	@Test
+	public void conversionWorksForStateDisconnected() {
+		whenInt32StateIsPassed(new UInt32(30));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+	}
+
+	@Test
+	public void conversionWorksForStatePrepare() {
+		whenInt32StateIsPassed(new UInt32(40));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_PREPARE);
+	}
+
+	@Test
+	public void conversionWorksForStateConfig() {
+		whenInt32StateIsPassed(new UInt32(50));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_CONFIG);
+	}
+
+	@Test
+	public void conversionWorksForStateNeedAuth() {
+		whenInt32StateIsPassed(new UInt32(60));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
+	}
+
+	@Test
+	public void conversionWorksForStateIpConfig() {
+		whenInt32StateIsPassed(new UInt32(70));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
+	}
+
+	@Test
+	public void conversionWorksForStateIpCheck() {
+		whenInt32StateIsPassed(new UInt32(80));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
+	}
+
+	@Test
+	public void conversionWorksForStateSecondaries() {
+		whenInt32StateIsPassed(new UInt32(90));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
+	}
+
+	@Test
+	public void conversionWorksForStateActivated() {
+		whenInt32StateIsPassed(new UInt32(100));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+	}
+
+	@Test
+	public void conversionWorksForStateDeactivating() {
+		whenInt32StateIsPassed(new UInt32(110));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
+	}
+
+	@Test
+	public void conversionWorksForStateFailed() {
+		whenInt32StateIsPassed(new UInt32(120));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_FAILED);
+	}
+
+	@Test
+	public void conversionWorksForStateUnknownDefault() {
+		whenInt32StateIsPassed(new UInt32(121));
+		thenCorrectStateIsReturned(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+	}
+
+	@Test
+	public void shouldReturnConnectionFalseUnknown() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+		thenStateShouldBeEqualTo(false);
+	}
+
+	@Test
+	public void shouldReturnConnectionFalseUnmanaged() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
+		thenStateShouldBeEqualTo(false);
+	}
+
+	@Test
+	public void shouldReturnConnectionFalseUnavailable() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
+		thenStateShouldBeEqualTo(false);
+	}
+
+	@Test
+	public void shouldReturnConnectionFalseDisconnected() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+		thenStateShouldBeEqualTo(false);
+	}
+
+	@Test
+	public void shouldReturnConnectionTruePrepare() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_PREPARE);
+		thenStateShouldBeEqualTo(true);
+	}
+
+	@Test
+	public void shouldReturnConnectionTrueConfig() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_CONFIG);
+		thenStateShouldBeEqualTo(true);
+	}
+
+	@Test
+	public void shouldReturnConnectionTrueNeedAuth() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
+		thenStateShouldBeEqualTo(true);
+	}
+
+	@Test
+	public void shouldReturnConnectionTrueIpConfig() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
+		thenStateShouldBeEqualTo(true);
+	}
+
+	@Test
+	public void shouldReturnConnectionTrueIpCheck() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
+		thenStateShouldBeEqualTo(true);
+	}
+
+	@Test
+	public void shouldReturnConnectionTrueSecondaries() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
+		thenStateShouldBeEqualTo(true);
+	}
+
+	@Test
+	public void shouldReturnConnectionTrueActivated() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+		thenStateShouldBeEqualTo(true);
+	}
+
+	@Test
+	public void shouldReturnConnectionTrueDeactivating() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
+		thenStateShouldBeEqualTo(true);
+	}
+
+	@Test
+	public void shouldReturnConnectionTrueFailed() {
+		whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_FAILED);
+		thenStateShouldBeEqualTo(true);
+	}
+
+	public void whenInt32StateIsPassed(UInt32 type) {
+		state = NMDeviceState.fromUInt32(type);
+	}
+
+	public void whenStateIsSetTo(NMDeviceState type) {
+		state = type;
+	}
+
+	public void thenCorrectStateIsReturned(NMDeviceState type) {
+		assertEquals(state, type);
+	}
+
+	public void thenStateShouldBeEqualTo(Boolean bool) {
+		assertEquals(NMDeviceState.isConnected(state), bool);
+	}
 
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceTypeTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceTypeTest.java
@@ -1,0 +1,189 @@
+package org.eclipse.kura.nm.configuration;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.kura.KuraException;
+import org.freedesktop.dbus.types.UInt32;
+import org.junit.Test;
+
+public class NMDeviceTypeTest {
+	
+	NMDeviceType type;
+
+    @Test
+    public void shouldReturnCorrectTypeFromUIntZero() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(0));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_UNKNOWN);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntOne() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(1));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwo() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(2));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WIFI);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntThree() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(3));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_UNUSED1);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntFour() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(4));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_UNUSED2);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntFive() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(5));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_BT);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntSix() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(6));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_OLPC_MESH);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntSeven() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(7));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WIMAX);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntEight() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(8));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_MODEM);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntNine() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(9));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_INFINIBAND);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(10));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_BOND);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntEleven() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(11));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_VLAN);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwelve() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(12));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_ADSL);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntThirteen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(13));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_BRIDGE);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntFourteen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(14));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_GENERIC);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntFifteen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(15));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_TEAM);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntSixteen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(16));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_TUN);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntSeventeen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(17));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_IP_TUNNEL);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntEightteen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(18));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_MACVLAN);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntNineteen() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(19));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_VXLAN);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwenty() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(20));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_VETH);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwentyOne() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(21));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_MACSEC);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwentyTwo() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(22));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_DUMMY);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwentyThree() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(23));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_PPP);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwentyFour() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(24));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_OVS_INTERFACE);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwentyFive() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(25));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_OVS_PORT);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwentySix() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(26));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_OVS_BRIDGE);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwentySeven() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(27));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WPAN);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwentyEight() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(28));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_6LOWPAN);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntTwentyNine() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(29));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WIREGUARD);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntThirty() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(30));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WIFI_P2P);
+    }
+    @Test
+    public void shouldReturnCorrectTypeFromUIntThirtyOne() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(31));
+    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_VRF);
+    }
+    
+    @Test
+    public void shouldReturnCorrectTypeFromUIntThirtydefault() throws InterruptedException, KuraException {
+    	whenInt32StateIsPassed(new UInt32(32));
+    	thenCorrectTypeIsReturned(null);
+    }
+
+	private void whenInt32StateIsPassed(UInt32 type) {
+		this.type = NMDeviceType.fromUInt32(type);
+	}
+	
+	private void thenCorrectTypeIsReturned(NMDeviceType type) {
+		assertEquals(this.type, type);
+		
+	}
+    
+}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceTypeTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMDeviceTypeTest.java
@@ -7,183 +7,214 @@ import org.freedesktop.dbus.types.UInt32;
 import org.junit.Test;
 
 public class NMDeviceTypeTest {
-	
+
 	NMDeviceType type;
 
-    @Test
-    public void shouldReturnCorrectTypeFromUIntZero() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(0));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_UNKNOWN);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntOne() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(1));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwo() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(2));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WIFI);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntThree() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(3));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_UNUSED1);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntFour() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(4));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_UNUSED2);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntFive() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(5));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_BT);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntSix() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(6));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_OLPC_MESH);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntSeven() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(7));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WIMAX);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntEight() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(8));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_MODEM);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntNine() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(9));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_INFINIBAND);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(10));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_BOND);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntEleven() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(11));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_VLAN);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwelve() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(12));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_ADSL);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntThirteen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(13));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_BRIDGE);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntFourteen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(14));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_GENERIC);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntFifteen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(15));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_TEAM);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntSixteen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(16));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_TUN);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntSeventeen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(17));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_IP_TUNNEL);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntEightteen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(18));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_MACVLAN);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntNineteen() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(19));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_VXLAN);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwenty() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(20));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_VETH);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwentyOne() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(21));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_MACSEC);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwentyTwo() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(22));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_DUMMY);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwentyThree() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(23));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_PPP);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwentyFour() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(24));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_OVS_INTERFACE);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwentyFive() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(25));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_OVS_PORT);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwentySix() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(26));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_OVS_BRIDGE);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwentySeven() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(27));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WPAN);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwentyEight() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(28));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_6LOWPAN);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntTwentyNine() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(29));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WIREGUARD);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntThirty() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(30));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_WIFI_P2P);
-    }
-    @Test
-    public void shouldReturnCorrectTypeFromUIntThirtyOne() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(31));
-    	thenCorrectTypeIsReturned(NMDeviceType.NM_DEVICE_TYPE_VRF);
-    }
-    
-    @Test
-    public void shouldReturnCorrectTypeFromUIntThirtydefault() throws InterruptedException, KuraException {
-    	whenInt32StateIsPassed(new UInt32(32));
-    	thenCorrectTypeIsReturned(null);
-    }
+	@Test
+	public void conversionWorksForTypeUnknown() {
+		whenInt32StateIsPassed(new UInt32(0));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_UNKNOWN);
+	}
+
+	@Test
+	public void conversionWorksForTypeEthernet() {
+		whenInt32StateIsPassed(new UInt32(1));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+	}
+
+	@Test
+	public void conversionWorksForTypeWiFi() {
+		whenInt32StateIsPassed(new UInt32(2));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_WIFI);
+	}
+
+	@Test
+	public void conversionWorksForTypeUnused() {
+		whenInt32StateIsPassed(new UInt32(3));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_UNUSED1);
+	}
+
+	@Test
+	public void conversionWorksForTypeUnused2() {
+		whenInt32StateIsPassed(new UInt32(4));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_UNUSED2);
+	}
+
+	@Test
+	public void conversionWorksForTypeBt() {
+		whenInt32StateIsPassed(new UInt32(5));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_BT);
+	}
+
+	@Test
+	public void conversionWorksForTypeOlpcMesh() {
+		whenInt32StateIsPassed(new UInt32(6));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_OLPC_MESH);
+	}
+
+	@Test
+	public void conversionWorksForTypeWiMax() {
+		whenInt32StateIsPassed(new UInt32(7));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_WIMAX);
+	}
+
+	@Test
+	public void conversionWorksForTypeModem() {
+		whenInt32StateIsPassed(new UInt32(8));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_MODEM);
+	}
+
+	@Test
+	public void conversionWorksForTypeInfiniband() {
+		whenInt32StateIsPassed(new UInt32(9));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_INFINIBAND);
+	}
+
+	@Test
+	public void conversionWorksForTypeBond() {
+		whenInt32StateIsPassed(new UInt32(10));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_BOND);
+	}
+
+	@Test
+	public void conversionWorksForTypeVlan() {
+		whenInt32StateIsPassed(new UInt32(11));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_VLAN);
+	}
+
+	@Test
+	public void conversionWorksForTypeAdsl() {
+		whenInt32StateIsPassed(new UInt32(12));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_ADSL);
+	}
+
+	@Test
+	public void conversionWorksForTypeBridge() {
+		whenInt32StateIsPassed(new UInt32(13));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_BRIDGE);
+	}
+
+	@Test
+	public void conversionWorksForTypeGeneric() {
+		whenInt32StateIsPassed(new UInt32(14));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_GENERIC);
+	}
+
+	@Test
+	public void conversionWorksForTypeTeam() {
+		whenInt32StateIsPassed(new UInt32(15));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_TEAM);
+	}
+
+	@Test
+	public void conversionWorksForTypeTun() {
+		whenInt32StateIsPassed(new UInt32(16));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_TUN);
+	}
+
+	@Test
+	public void conversionWorksForTypeIpTunnel() {
+		whenInt32StateIsPassed(new UInt32(17));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_IP_TUNNEL);
+	}
+
+	@Test
+	public void conversionWorksForTypeMacVlan() {
+		whenInt32StateIsPassed(new UInt32(18));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_MACVLAN);
+	}
+
+	@Test
+	public void conversionWorksForTypeVxlan() {
+		whenInt32StateIsPassed(new UInt32(19));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_VXLAN);
+	}
+
+	@Test
+	public void conversionWorksForTypeVeth() {
+		whenInt32StateIsPassed(new UInt32(20));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_VETH);
+	}
+
+	@Test
+	public void conversionWorksForTypeMacsec() {
+		whenInt32StateIsPassed(new UInt32(21));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_MACSEC);
+	}
+
+	@Test
+	public void conversionWorksForTypeDummy() {
+		whenInt32StateIsPassed(new UInt32(22));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_DUMMY);
+	}
+
+	@Test
+	public void conversionWorksForTypePpp() {
+		whenInt32StateIsPassed(new UInt32(23));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_PPP);
+	}
+
+	@Test
+	public void conversionWorksForTypeOvsInterface() {
+		whenInt32StateIsPassed(new UInt32(24));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_OVS_INTERFACE);
+	}
+
+	@Test
+	public void conversionWorksForTypeOvsPort() {
+		whenInt32StateIsPassed(new UInt32(25));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_OVS_PORT);
+	}
+
+	@Test
+	public void conversionWorksForTypeOvsBridge() {
+		whenInt32StateIsPassed(new UInt32(26));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_OVS_BRIDGE);
+	}
+
+	@Test
+	public void conversionWorksForTypeWpan() {
+		whenInt32StateIsPassed(new UInt32(27));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_WPAN);
+	}
+
+	@Test
+	public void conversionWorksForType6LowPan() {
+		whenInt32StateIsPassed(new UInt32(28));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_6LOWPAN);
+	}
+
+	@Test
+	public void conversionWorksForTypeWireguard() {
+		whenInt32StateIsPassed(new UInt32(29));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_WIREGUARD);
+	}
+
+	@Test
+	public void conversionWorksForTypeWiFiP2p() {
+		whenInt32StateIsPassed(new UInt32(30));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_WIFI_P2P);
+	}
+
+	@Test
+	public void conversionWorksForTypeVrf() {
+		whenInt32StateIsPassed(new UInt32(31));
+		thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_VRF);
+	}
+
+	@Test
+	public void conversionWorksForTypeNull() {
+		whenInt32StateIsPassed(new UInt32(32));
+		thenTypeShouldBeEqualTo(null);
+	}
 
 	private void whenInt32StateIsPassed(UInt32 type) {
 		this.type = NMDeviceType.fromUInt32(type);
 	}
-	
-	private void thenCorrectTypeIsReturned(NMDeviceType type) {
+
+	private void thenTypeShouldBeEqualTo(NMDeviceType type) {
 		assertEquals(this.type, type);
-		
+
 	}
-    
+
 }


### PR DESCRIPTION
This PR includes two new unit test classes, which should fully cover NMDeviceState and NMDeviceType.


**Related Issue:** n/a

**Description of the solution adopted:** n/a

**Screenshots:** n/a

**Any side note on the changes made:** n/a
