### PR TITLE
tests: add test coverage for NMSettingsConverter

### DIFF
--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.nm.configuration;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.freedesktop.dbus.types.Variant;
+import org.freedesktop.networkmanager.settings.Connection;
+import org.junit.Test;
+
+public class NMSettingsConverterTest {
+
+	Map<String, Variant<?>> internalComparatorMap;
+	Map<String, Variant<?>> resultMap;
+	
+	Map<String, Map<String, Variant<?>>> internalComparatorAllSettingsMap;
+	Map<String, Map<String, Variant<?>>> resultAllSettingsMap;
+	
+	NetworkProperties props;
+
+	@Test(expected=IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuildSettingsWithEmptyMap() {
+		//TODO
+		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
+		givenBlankNetworkProps();
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.props, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuildIpv4SettingsWithEmptyMap() {
+		//TODO
+		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
+		givenBlankNetworkProps();
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.props, "wlan0");
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuildIpv6SettingsWithEmptyMap() {
+		//TODO
+		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
+		givenBlankNetworkProps();
+		whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(this.props, "wlan0");
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuild80211WirelessSettingsWithEmptyMap() {
+		//TODO
+		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
+		givenBlankNetworkProps();
+		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.props, "wlan0");
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuild80211WirelessSecuritySettingsWithEmptyMap() {
+		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
+		givenBlankNetworkProps();
+		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.props, "wlan0");
+	}
+
+	// given
+
+	public void givenTheExpectedMapOutputBuild80211WirelessSecuritySettings() {
+		internalComparatorMap = new HashMap<>();
+	}
+	
+	public void givenBlankNetworkProps() {
+		this.props = new NetworkProperties(new HashMap<String, Object>());
+	}
+	
+
+	// when
+
+	public void whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties properties,
+            Optional<Connection> oldConnection, String iface, NMDeviceType deviceType) {
+		this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
+	}
+	
+	public void whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+		this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
+	}
+	
+	public void whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+		this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
+	}
+	
+	public void whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+		this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
+	}
+	
+	public void whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+		this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
+	}
+
+	// then
+
+	public void thenMapResultShouldEqualInternalMap() {
+		assertEquals(this.resultMap, this.internalComparatorMap);
+	}
+
+}
+

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -14,10 +14,15 @@ package org.eclipse.kura.nm.configuration;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.eclipse.kura.configuration.Password;
+import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.networkmanager.settings.Connection;
 import org.junit.Test;
@@ -26,90 +31,303 @@ public class NMSettingsConverterTest {
 
 	Map<String, Variant<?>> internalComparatorMap;
 	Map<String, Variant<?>> resultMap;
-	
+
 	Map<String, Map<String, Variant<?>>> internalComparatorAllSettingsMap;
 	Map<String, Map<String, Variant<?>>> resultAllSettingsMap;
-	
-	NetworkProperties props;
 
-	@Test(expected=IllegalArgumentException.class)
+	Map<String, Object> internetNetworkPropertiesInstanciationMap;
+
+	NetworkProperties networkProperties;
+
+	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowErrorWhenBuildSettingsWithEmptyMap() {
-		//TODO
-		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
-		givenBlankNetworkProps();
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.props, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
+				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
+
+	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowErrorWhenBuildIpv4SettingsWithEmptyMap() {
-		//TODO
-		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
-		givenBlankNetworkProps();
-		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.props, "wlan0");
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
+
+	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowErrorWhenBuildIpv6SettingsWithEmptyMap() {
-		//TODO
-		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
-		givenBlankNetworkProps();
-		whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(this.props, "wlan0");
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
+
+	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowErrorWhenBuild80211WirelessSettingsWithEmptyMap() {
-		//TODO
-		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
-		givenBlankNetworkProps();
-		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.props, "wlan0");
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
+
+	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowErrorWhenBuild80211WirelessSecuritySettingsWithEmptyMap() {
-		givenTheExpectedMapOutputBuild80211WirelessSecuritySettings();
-		givenBlankNetworkProps();
-		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.props, "wlan0");
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpEnabledForWAN() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledWAN");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
+				"netIPv4StatusEnabledWAN");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpDisabledForWAN() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledWAN");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
+				"netIPv4StatusEnabledWAN");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpEnabledForLAN() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledLAN");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
+				"netIPv4StatusEnabledLAN");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpDisabledForLAN() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledLAN");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
+				"netIPv4StatusEnabledLAN");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpDisabledForOther() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
+				"netIPv4StatusUnmanaged");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuild80211WirelessSettingsWithExpectedInputs() {
+		givenEmptyMaps();
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuild80211WirelessSecurityWithExpectedInputs() {
+		givenEmptyMaps();
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuildSettingsWithExpectedInputs() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
+				"netIPv4StatusUnmanaged");
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true);
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
+				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		thenMapResultShouldEqualInternalBuildMap();
 	}
 
 	// given
 
-	public void givenTheExpectedMapOutputBuild80211WirelessSecuritySettings() {
+	public void givenEmptyMaps() {
 		internalComparatorMap = new HashMap<>();
+		resultMap = new HashMap<>();
+		internalComparatorAllSettingsMap = new HashMap<>();
+		resultAllSettingsMap = new HashMap<>();
+		internetNetworkPropertiesInstanciationMap = new HashMap<>();
 	}
-	
-	public void givenBlankNetworkProps() {
-		this.props = new NetworkProperties(new HashMap<String, Object>());
+
+	public void givenNetworkPropsCreatedWithTheMap(Map<String, Object> properties) {
+		this.networkProperties = new NetworkProperties(properties);
 	}
-	
+
+	public void givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(String inter, Boolean dhcpStatus,
+			String netStatus) {
+		internetNetworkPropertiesInstanciationMap
+				.put(String.format("net.interface.%s.config.dhcpClient4.enabled", inter), dhcpStatus);
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.status", inter),
+				netStatus);
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.address", inter),
+				"192.168.0.12");
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.prefix", inter),
+				(short) 25);
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.dnsServers", inter),
+				"1.1.1.1");
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.gateway", inter),
+				"192.168.0.1");
+	}
+
+	public void givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(String inter,
+			Boolean dhcpStatus, String netStatus) {
+
+		if (!dhcpStatus) {
+			internalComparatorMap.put("method", new Variant<>("manual"));
+
+			Map<String, Variant<?>> addressEntry = new HashMap<>();
+			addressEntry.put("address", new Variant<>("192.168.0.12"));
+			addressEntry.put("prefix", new Variant<>(new UInt32(25)));
+
+			List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
+			internalComparatorMap.put("address-data", new Variant<>(addressData, "aa{sv}"));
+
+		} else {
+			internalComparatorMap.put("method", new Variant<>("auto"));
+		}
+
+		if (netStatus.equals("netIPv4StatusEnabledLAN")) {
+			internalComparatorMap.put("ignore-auto-dns", new Variant<>(true));
+			internalComparatorMap.put("ignore-auto-routes", new Variant<>(true));
+		} else if (netStatus.equals("netIPv4StatusEnabledWAN")) {
+			Optional<List<String>> dnsServers = Optional.of(List.of("1.1.1.1"));
+			if (dnsServers.isPresent()) {
+				internalComparatorMap.put("dns", new Variant<>(List.of(new UInt32(16843009)), "au"));
+				internalComparatorMap.put("ignore-auto-dns", new Variant<>(true));
+			}
+			Optional<String> gateway = Optional.of("192.168.0.1");
+			if (gateway.isPresent()) {
+				internalComparatorMap.put("gateway", new Variant<>(gateway.get()));
+			}
+		}
+
+	}
+
+	public void givenValid80211WirelessSettingsWithInterfaceNameAndSsid(String inter, String ssid, String propMode,
+			Boolean channelEnabled) {
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.wifi.mode", inter),
+				propMode);
+		internetNetworkPropertiesInstanciationMap
+				.put(String.format("net.interface.%s.config.wifi.%s.ssid", inter, propMode.toLowerCase()), ssid);
+		internetNetworkPropertiesInstanciationMap.put(
+				String.format("net.interface.%s.config.wifi.%s.radioMode", inter, propMode.toLowerCase()),
+				"RADIO_MODE_80211a");
+		if (channelEnabled) {
+			internetNetworkPropertiesInstanciationMap
+					.put(String.format("net.interface.%s.config.wifi.%s.channel", inter, propMode.toLowerCase()), "10");
+		}
+	}
+
+	public void givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(String inter, String ssid,
+			String propMode, Boolean channelEnabled) {
+		internalComparatorMap.put("mode", new Variant<>(propMode));
+		// TODO: investigate this .getBytes discrepancy
+		internalComparatorMap.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
+		internalComparatorMap.put("band", new Variant<>("a"));
+		if (channelEnabled) {
+			internalComparatorMap.put("channel", new Variant<>(new UInt32(Short.parseShort("10"))));
+		}
+	}
+
+	public void givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(String inter, String ssid,
+			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.wifi.mode", inter),
+				propMode);
+		internetNetworkPropertiesInstanciationMap.put(
+				String.format("net.interface.%s.config.wifi.%s.passphrase", inter, propMode.toLowerCase()),
+				new Password("test"));
+		internetNetworkPropertiesInstanciationMap.put(
+				String.format("net.interface.%s.config.wifi.%s.securityType", inter, propMode.toLowerCase()),
+				"SECURITY_WPA_WPA2"); // wpa
+		if (groupEnabled) {
+			internetNetworkPropertiesInstanciationMap.put(
+					String.format("net.interface.%s.config.wifi.%s.groupCiphers", inter, propMode.toLowerCase()),
+					"CCMP"); // option
+		}
+		if (ciphersEnabled) {
+			internetNetworkPropertiesInstanciationMap.put(
+					String.format("net.interface.%s.config.wifi.%s.pairwiseCiphers", inter, propMode.toLowerCase()),
+					"CCMP"); // ccmp
+		}
+	}
+
+	public void givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(String inter, String ssid,
+			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
+
+		internalComparatorMap.put("psk", new Variant<>(new Password("test").toString()));
+		internalComparatorMap.put("key-mgmt", new Variant<>("wpa-psk"));
+
+		if (groupEnabled) {
+			internalComparatorMap.put("group", new Variant<>(Arrays.asList("ccmp"), "as"));
+		}
+
+		if (ciphersEnabled) {
+			internalComparatorMap.put("pairwise", new Variant<>(Arrays.asList("ccmp"), "as"));
+		}
+
+	}
 
 	// when
 
 	public void whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties properties,
-            Optional<Connection> oldConnection, String iface, NMDeviceType deviceType) {
+			Optional<Connection> oldConnection, String iface, NMDeviceType deviceType) {
 		this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
 	}
-	
+
 	public void whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
 		this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
 	}
-	
+
 	public void whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
 		this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
 	}
-	
-	public void whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+
+	public void whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props,
+			String iface) {
 		this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
 	}
-	
-	public void whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+
+	public void whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props,
+			String iface) {
 		this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
 	}
 
 	// then
 
 	public void thenMapResultShouldEqualInternalMap() {
-		assertEquals(this.resultMap, this.internalComparatorMap);
+		assertEquals(this.internalComparatorMap, this.resultMap);
+	}
+
+	public void thenMapResultShouldEqualInternalBuildMap() {
+		assertEquals(this.internalComparatorAllSettingsMap, this.resultAllSettingsMap);
 	}
 
 }
-


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
